### PR TITLE
Add DesktopSize / ExtendedDesktopSize pseudo-encoding support

### DIFF
--- a/asyncvnc2.py
+++ b/asyncvnc2.py
@@ -50,6 +50,10 @@ class Enc(Enum):
 
     Default priority order is ZRLE, TRLE, ZLIB, COPY, RAW.
 
+    Pseudo-encodings (negative values per the RFB spec) carry server
+    notifications rather than pixel data and are not advertised by default
+    in SetEncodings -- the dispatch in Video.read still handles them if a
+    server pushes one unsolicited (e.g. on a server-side geometry change).
     """
 
     #: ZRLE encoding.
@@ -67,12 +71,26 @@ class Enc(Enum):
     #: Raw encoding.
     RAW = 0
 
+    #: DesktopSize pseudo-encoding (RFB §7.7.2). Server-side geometry
+    #: change; rect.width/height carry the new dimensions, no payload.
+    DESKTOP_SIZE = -223
+
+    #: ExtendedDesktopSize pseudo-encoding (libvncserver/RealVNC ext).
+    #: Same intent as DESKTOP_SIZE plus a multi-screen layout payload.
+    EXTENDED_DESKTOP_SIZE = -308
+
     @classmethod
     def default(cls):
         """
-        Get a list of supported encodings expect RAW.
+        Get the default list of supported encodings.
+
+        Excludes RAW (value 0) and pseudo-encodings (negative). Callers
+        wanting resize notifications can opt in explicitly, e.g.
+        ``EncList() + Enc.EXTENDED_DESKTOP_SIZE``, but be aware that
+        TigerVNC treats EDS in SetEncodings as a subscription that returns
+        EDS-only FBU responses, starving the screenshot path of pixel data.
         """
-        return filter(lambda x: x.value != 0, cls)
+        return filter(lambda x: x.value > 0, cls)
 
 class EncList(list):
     """
@@ -542,7 +560,8 @@ class Video:
             writer.write(b'\x00\x00\x00\x00' + video_definition.get(mode) + b'\x00\x00\x00')
 
         writer.write(b'\x02\x00'+len(encodings).to_bytes(2, 'big'))
-        writer.write(b''.join(map(lambda x: x.value.to_bytes(4, 'big'), encodings)))
+        # signed=True to allow pseudo-encodings (negative values per RFB spec).
+        writer.write(b''.join(map(lambda x: x.value.to_bytes(4, 'big', signed=True), encodings)))
 
         decompress = decompressobj()
 
@@ -587,6 +606,27 @@ class Video:
             y.to_bytes(2, 'big') +
             width.to_bytes(2, 'big') +
             height.to_bytes(2, 'big'))
+
+    def _handle_desktop_resize(self, new_width: int, new_height: int):
+        """
+        Apply a DesktopSize / ExtendedDesktopSize pseudo-encoding rect.
+
+        Only invalidates the framebuffer on an actual size change. Some
+        servers echo the current size as an informational EDS rect even
+        when nothing changed; treating that as "data invalid + need
+        refresh" would deadlock the screenshot path.
+
+        Does not auto-request a refresh -- callers (Client.screenshot)
+        check whether their region became incomplete and re-request as
+        needed. This keeps the rect handler free of side effects on the
+        writer side, which would otherwise race with in-flight FBURs.
+        """
+        if (new_width, new_height) == (self.width, self.height):
+            return
+        self.width = new_width
+        self.height = new_height
+        self.data = None
+        self.serial = (self.serial + 1) & 0xfffffff
 
     def _update_rect(self, x1: int, x2: int, y1: int, y2: int, data: np.ndarray):
         """
@@ -662,7 +702,12 @@ class Video:
         y = await read_int(self.reader, 2)
         width = await read_int(self.reader, 2)
         height = await read_int(self.reader, 2)
-        encoding = Enc(await read_int(self.reader, 4))
+        # Encoding number is signed 32-bit on the wire. read_int is unsigned,
+        # so convert wrap-around values back to negative for pseudo-encodings.
+        raw_enc = await read_int(self.reader, 4)
+        if raw_enc > 0x7FFFFFFF:
+            raw_enc -= 0x100000000
+        encoding = Enc(raw_enc)
         length = height * width * 4
 #        print(f"GET VIDEO REC: {x} {y} {width}x{height} / {encoding}")
 
@@ -687,6 +732,20 @@ class Video:
         elif encoding is Enc.COPY:
             await self.process_copy(self.reader,
                                  x, y, width, height)
+
+        elif encoding is Enc.DESKTOP_SIZE:
+            # No payload -- rect.width/height carry the new dimensions.
+            self._handle_desktop_resize(width, height)
+
+        elif encoding is Enc.EXTENDED_DESKTOP_SIZE:
+            # Payload: num_screens (u8) + 3 padding bytes, then per-screen
+            # records (16 bytes each: id u32, x u16, y u16, w u16, h u16,
+            # flags u32). We don't surface per-screen info; rect.width/height
+            # carry the new framebuffer dimensions.
+            num_screens = await read_int(self.reader, 1)
+            await self.reader.readexactly(3)  # reserved padding
+            await self.reader.readexactly(num_screens * 16)
+            self._handle_desktop_resize(width, height)
 
         else:
             raise ValueError(encoding)
@@ -932,6 +991,11 @@ class Client:
             if update_type is UpdateType.VIDEO:
                 if self.video.is_complete(x, y, width, height):
                     return self.video.as_rgba(x, y, width, height)
+                # FBU arrived but didn't fill the requested region. Common
+                # causes: an unsolicited DESKTOP_SIZE/EDS rect invalidated
+                # the buffer mid-stream, or the server split the response.
+                # Re-request to keep the loop making progress.
+                self.video.refresh(x, y, width, height)
 
 
 @asynccontextmanager

--- a/tests/test_desktop_size.py
+++ b/tests/test_desktop_size.py
@@ -1,0 +1,102 @@
+from asyncio import StreamReader
+from io import BytesIO
+
+import numpy as np
+import pytest
+
+from asyncvnc2 import Enc, Video
+
+
+def _make_video(reader=None, width=1024, height=768) -> Video:
+    """Build a Video for unit testing -- no live VNC connection."""
+    return Video(
+        reader=reader,
+        writer=BytesIO(),
+        decompress=lambda data: data,
+        name='DESKTOP',
+        width=width,
+        height=height,
+        mode='RGBA')
+
+
+def _rect_header(x: int, y: int, width: int, height: int, encoding: int) -> bytes:
+    """Encode a framebuffer-update rectangle header (12 bytes)."""
+    return (
+        x.to_bytes(2, 'big') +
+        y.to_bytes(2, 'big') +
+        width.to_bytes(2, 'big') +
+        height.to_bytes(2, 'big') +
+        encoding.to_bytes(4, 'big', signed=True))
+
+
+def _reader_with(data: bytes) -> StreamReader:
+    """StreamReader pre-loaded with canned bytes. Requires a running loop."""
+    reader = StreamReader()
+    reader._buffer.extend(bytearray(data))
+    return reader
+
+
+# -- _handle_desktop_resize -----------------------------------------------
+
+def test_handle_desktop_resize_noop_on_unchanged_size():
+    video = _make_video()
+    video.data = np.zeros((video.height, video.width, 4), 'B')
+    serial_before = video.serial
+    video._handle_desktop_resize(video.width, video.height)
+    assert video.data is not None  # not invalidated
+    assert video.serial == serial_before  # not bumped
+
+
+def test_handle_desktop_resize_invalidates_on_change():
+    video = _make_video()
+    video.data = np.zeros((video.height, video.width, 4), 'B')
+    serial_before = video.serial
+    video._handle_desktop_resize(1280, 720)
+    assert video.width == 1280
+    assert video.height == 720
+    assert video.data is None  # framebuffer invalidated
+    assert video.serial == serial_before + 1
+
+
+# -- Video.read with DESKTOP_SIZE pseudo-encoding -------------------------
+
+@pytest.mark.asyncio
+async def test_read_desktop_size_rect():
+    rect = _rect_header(0, 0, 800, 600, Enc.DESKTOP_SIZE.value)
+    video = _make_video(reader=_reader_with(rect))
+    await video.read()
+    assert (video.width, video.height) == (800, 600)
+    assert video.data is None
+
+
+# -- Video.read with EXTENDED_DESKTOP_SIZE pseudo-encoding ----------------
+
+@pytest.mark.asyncio
+async def test_read_extended_desktop_size_drains_payload():
+    # EDS rect: header + (num_screens=1) + 3 padding bytes + one 16-byte
+    # screen record. After read() returns, the buffer must be empty so the
+    # next rect's parser doesn't see leftover bytes.
+    screen_record = (
+        b'\x00\x00\x00\x01' +  # screen id
+        b'\x00\x00' + b'\x00\x00' +  # x, y position
+        (1600).to_bytes(2, 'big') +  # width
+        (900).to_bytes(2, 'big') +   # height
+        b'\x00\x00\x00\x00')         # flags
+    payload = b'\x01' + b'\x00\x00\x00' + screen_record
+    rect = _rect_header(0, 0, 1600, 900, Enc.EXTENDED_DESKTOP_SIZE.value) + payload
+    video = _make_video(reader=_reader_with(rect))
+    await video.read()
+    assert (video.width, video.height) == (1600, 900)
+    assert len(video.reader._buffer) == 0  # full payload consumed
+
+
+@pytest.mark.asyncio
+async def test_read_extended_desktop_size_multiple_screens():
+    # Two screens -> payload size is 1 + 3 + 32 = 36 bytes after header.
+    screen_record = b'\x00' * 16
+    payload = b'\x02' + b'\x00\x00\x00' + (screen_record * 2)
+    rect = _rect_header(0, 0, 2560, 1080, Enc.EXTENDED_DESKTOP_SIZE.value) + payload
+    video = _make_video(reader=_reader_with(rect))
+    await video.read()
+    assert (video.width, video.height) == (2560, 1080)
+    assert len(video.reader._buffer) == 0


### PR DESCRIPTION
The RFB pseudo-encodings -223 (DesktopSize) and -308 (ExtendedDesktopSize) carry server-side geometry change notifications. asyncvnc2 currently has no parser for them, so when a server pushes one (TigerVNC does this on every `xrandr` resize, for example), `Enc(...)` raises `ValueError` and the connection drops on the next byte read.

### What changed

- `Enc` gains `DESKTOP_SIZE = -223` and `EXTENDED_DESKTOP_SIZE = -308`.
- The `SetEncodings` writer uses `signed=True` so negative pseudo-encodings serialize correctly when callers opt them in via `EncList`.
- `Video.read` converts the unsigned wire integer back to signed before the `Enc(...)` lookup. Existing raise-on-unknown-encoding behavior is preserved (silently skipping an unknown rect would desync the stream).
- Two new dispatch branches drain the pseudo-encoding payload and update `Video.width/height` through a small `_handle_desktop_resize` helper that only invalidates the framebuffer when the size actually changes (servers commonly echo the current size on connect).
- `Client.screenshot` re-requests on incomplete updates so callers don't deadlock when an unsolicited pseudo-encoding rect arrives mid-screenshot.
- `Enc.default()` now excludes pseudo-encodings (filter `value > 0`) with a docstring explaining the TigerVNC subscription quirk — see below.
- `tests/test_desktop_size.py` adds 5 unit tests covering `_handle_desktop_resize` no-op vs invalidate semantics and `Video.read` parsing of DESKTOP_SIZE plus EDS rects (including multi-screen payloads).

### TigerVNC subscription quirk

If you advertise `ExtendedDesktopSize` in `SetEncodings`, the TigerVNC build in `accetto/ubuntu-vnc-xfce-g3` returns EDS-only `FramebufferUpdate` responses (cnt=1, no pixel data) to every `FramebufferUpdateRequest`, even with `incremental=False`. This effectively starves the screenshot path. The docstring on `Enc.default()` warns about this so users who want subscription-style resize notifications opt in deliberately: `EncList() + Enc.EXTENDED_DESKTOP_SIZE`.

### Verification

Tested against `accetto/ubuntu-vnc-xfce-g3` and the existing pytest suite. Default-behavior screenshots and the new resize handling both work; the test suite passes unchanged.